### PR TITLE
[JBIDE-15280] Update parent/pom.xml version to 4.2.0.Alpha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0.CR1-SNAPSHOT</version>
+		<version>4.2.0.Alpha1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>freemarker</artifactId>
@@ -18,5 +18,19 @@
 		<module>features</module>
 		<module>site</module>
 	</modules>
+	<repositories>
+		<!-- To resolve parent artifact -->
+		<repository>
+			<id>jboss-public-repository-group</id>
+			<name>JBoss Public Repository Group</name>
+			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>
 	


### PR DESCRIPTION
update parent pom version and added JBoss Public Group repo
http://repository.jboss.org/nexus/content/groups/public which according to
https://community.jboss.org/wiki/MavenRepository has everything we need to
build module out of the box without modification of ~/.m2/settings.xml

Build seems to be running with brand new local repo configured with
-Dmaven.repo.local=path/to/the/new/repository
