### PR TITLE
[JBIDE-20251] m2e exception after importing freemarker into eclipse

### DIFF
--- a/plugins/org.jboss.ide.eclipse.freemarker/.classpath
+++ b/plugins/org.jboss.ide.eclipse.freemarker/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
-	<classpathentry exported="true" kind="lib" path="freemarker-2.3.22.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/freemarker-2.3.22.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.jboss.ide.eclipse.freemarker/.gitignore
+++ b/plugins/org.jboss.ide.eclipse.freemarker/.gitignore
@@ -1,2 +1,2 @@
 /target/
-freemarker-*.jar
+lib

--- a/plugins/org.jboss.ide.eclipse.freemarker/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.ide.eclipse.freemarker/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.usage;bundle-version="1.0.0";resolution:=optional;x-installation:=greedy
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- freemarker-2.3.22.jar
+ lib/freemarker-2.3.22.jar
 Bundle-Vendor: %providerName
 Export-Package: freemarker.core,
  freemarker.template,

--- a/plugins/org.jboss.ide.eclipse.freemarker/build.properties
+++ b/plugins/org.jboss.ide.eclipse.freemarker/build.properties
@@ -1,12 +1,12 @@
 jars.compile.order = .
 bin.includes = plugin.*,\
-               freemarker-2.3.22.jar,\
                META-INF/,\
                .,\
                icons/,\
                License.txt,\
                about.*,\
-               jboss_about.png
+               jboss_about.png,\
+               lib/freemarker-2.3.22.jar
 src.includes = plugin.*,\
                icons/,\
                License.txt

--- a/plugins/org.jboss.ide.eclipse.freemarker/pom.xml
+++ b/plugins/org.jboss.ide.eclipse.freemarker/pom.xml
@@ -37,7 +37,7 @@
 						</artifactItem>
 					</artifactItems>
 					<skip>false</skip>
-					<outputDirectory>${basedir}</outputDirectory>
+					<outputDirectory>${basedir}/lib</outputDirectory>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Fix moves freemarker jar to lib folder and configures git to ignore
lib folder content