### PR TITLE
JBIDE-20381 ParseException when closing freemarker tag

### DIFF
--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/model/AssignmentDirective.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/model/AssignmentDirective.java
@@ -87,7 +87,10 @@ public class AssignmentDirective extends AbstractDirective {
 			try {
 				this.nestable = isNestable(getContents(), this.type);
 			} catch (ParseException e) {
-				Plugin.log(e);
+				// See https://issues.jboss.org/browse/JBIDE-20381 for details
+				// ParseException can occur here because when editor content is modified
+				// it doesn't stay correct all the time
+				// Plugin.log(e);
 				this.nestable = Boolean.FALSE;
 			}
 		}


### PR DESCRIPTION
Parse exceptions are expected when editor content is modified, because
if something is in the middle of modification it doesn't stay correct
all the time