### PR TITLE
JBIDE-20491: "incompatibleImprovements" setting should be set

### DIFF
--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Editor.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Editor.java
@@ -486,7 +486,7 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
 			try {
 				if (null != getFile()) {
 					if (null == fmConfiguration) {
-						fmConfiguration = new Configuration();
+						fmConfiguration = new Configuration(Configuration.getVersion());
 						fmConfiguration
 								.setTagSyntax(Configuration.AUTO_DETECT_TAG_SYNTAX);
 					}


### PR DESCRIPTION
Use the same incompatibleImprovements version as the version of the org.freemarker:freemarker dependency. (See in the Jira issue why.)