### PR TITLE
JBIDE-20387: Better error markers (end position, columns, editorMessage)

### DIFF
--- a/tests/org.jboss.ide.eclipse.freemarker.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface.text;bundle-version="3.5.1",
  org.eclipse.ui.views,
  org.eclipse.ui.editors,
- org.jboss.tools.locus.mockito;bundle-version="1.9.5"
+ org.jboss.tools.locus.mockito;bundle-version="1.9.5",
+ org.eclipse.ui.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/ErrorMarkerTest.java
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/ErrorMarkerTest.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss by Red Hat
+ * Copyright 2006-2009, Red Hat Middleware, LLC, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.ide.eclipse.freemarker.editor.test;
+
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.ide.ResourceUtil;
+import org.eclipse.ui.texteditor.MarkerUtilities;
+import org.jboss.ide.eclipse.freemarker.editor.Editor;
+import org.jboss.ide.eclipse.freemarker.editor.FreemarkerMultiPageEditor;
+import org.jboss.ide.eclipse.freemarker.test.Activator;
+import org.jboss.tools.test.util.ResourcesUtils;
+import org.jboss.tools.test.util.WorkbenchUtils;
+
+import junit.framework.TestCase;
+
+public class ErrorMarkerTest extends TestCase  {
+
+    private static final String EMPTY_FTL = "empty.ftl"; //$NON-NLS-1$
+    private static final String TEST_EDITOR_PROJECT = "testEditor"; //$NON-NLS-1$
+    
+    private Editor editor;
+
+    @Override
+    protected void setUp() throws Exception {
+        ResourcesUtils.importProject(Activator.PLUGIN_ID,"projects/" + TEST_EDITOR_PROJECT); //$NON-NLS-1$
+        IEditorPart editorPart = WorkbenchUtils.openEditor(TEST_EDITOR_PROJECT + IPath.SEPARATOR + EMPTY_FTL);
+        assertTrue(editorPart instanceof FreemarkerMultiPageEditor);
+        this.editor = ((FreemarkerMultiPageEditor) editorPart).getEditor();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        ResourcesUtils.deleteProject(TEST_EDITOR_PROJECT);
+    }
+
+    public void testMarkerPositions() throws CoreException {
+        // The "*" in "${*}" will be marked as error.
+
+        {
+            IMarker marker = getErrorMarker("${*}");
+            assertEquals(1, MarkerUtilities.getLineNumber(marker));
+            assertEquals(2, MarkerUtilities.getCharStart(marker));
+            assertEquals(3, MarkerUtilities.getCharEnd(marker));
+        }
+        
+        {
+            IMarker marker = getErrorMarker("\n\r\n\r${*}");
+            assertEquals(4, MarkerUtilities.getLineNumber(marker));
+            assertEquals(6, MarkerUtilities.getCharStart(marker));
+            assertEquals(7, MarkerUtilities.getCharEnd(marker));
+        }
+        
+        // Tabs are tricky because FreeMarker reports column numbers assuming tab width 8:
+        {
+            IMarker marker = getErrorMarker("\t${*}");
+            assertEquals(1, MarkerUtilities.getLineNumber(marker));
+            assertEquals(3, MarkerUtilities.getCharStart(marker));
+            assertEquals(4, MarkerUtilities.getCharEnd(marker));
+        }
+        {
+            IMarker marker = getErrorMarker(" \t${*}");
+            assertEquals(1, MarkerUtilities.getLineNumber(marker));
+            assertEquals(4, MarkerUtilities.getCharStart(marker));
+            assertEquals(5, MarkerUtilities.getCharEnd(marker));
+        }
+        {
+            IMarker marker = getErrorMarker("       \t${*}");
+            assertEquals(1, MarkerUtilities.getLineNumber(marker));
+            assertEquals(10, MarkerUtilities.getCharStart(marker));
+            assertEquals(11, MarkerUtilities.getCharEnd(marker));
+        }
+        {
+            IMarker marker = getErrorMarker("\t\t${*}");
+            assertEquals(1, MarkerUtilities.getLineNumber(marker));
+            assertEquals(4, MarkerUtilities.getCharStart(marker));
+            assertEquals(5, MarkerUtilities.getCharEnd(marker));
+        }
+        {
+            IMarker marker = getErrorMarker("\t  \t${*}");
+            assertEquals(1, MarkerUtilities.getLineNumber(marker));
+            assertEquals(6, MarkerUtilities.getCharStart(marker));
+            assertEquals(7, MarkerUtilities.getCharEnd(marker));
+        }
+        
+        // Strange case (parser bug?) where the error column is after the last character, so we must omit offset info:
+        {
+            IMarker marker = getErrorMarker("\n${#");
+            assertEquals(2, MarkerUtilities.getLineNumber(marker));
+            assertEquals(-1, MarkerUtilities.getCharStart(marker));
+            assertEquals(-1, MarkerUtilities.getCharEnd(marker));
+        }
+    }
+
+    protected IMarker getErrorMarker(String editorContent) throws CoreException {
+        editor.getDocument().set(editorContent);
+        editor.validateContents();
+        
+        IResource resource = ResourceUtil.getResource(editor.getEditorInput());
+        IMarker[] markers = resource.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+        
+        assertEquals(1, markers.length);
+        return markers[0];
+    }
+
+}

--- a/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/test/FreemarkerAllTests.java
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/test/FreemarkerAllTests.java
@@ -10,6 +10,7 @@ import org.jboss.ide.eclipse.freemarker.editor.coloring.test.InterpolationColori
 import org.jboss.ide.eclipse.freemarker.editor.coloring.test.ListColoringTest;
 import org.jboss.ide.eclipse.freemarker.editor.test.FreemarkerEditorTest;
 import org.jboss.ide.eclipse.freemarker.editor.test.IncludeHyperlinkDetectorTest;
+import org.jboss.ide.eclipse.freemarker.editor.test.ErrorMarkerTest;
 import org.jboss.ide.eclipse.freemarker.lang.test.ParserUtilsTest;
 import org.jboss.ide.eclipse.freemarker.model.test.AssignmentDirectiveTest;
 import org.jboss.ide.eclipse.freemarker.model.test.InterpolationTest;
@@ -25,6 +26,7 @@ public class FreemarkerAllTests extends TestCase {
 		suite.addTestSuite(FreemarkerPreferencePageTest.class);
 		suite.addTestSuite(FreemarkerEditorTest.class);
 		suite.addTestSuite(ParserUtilsTest.class);
+	    suite.addTestSuite(ErrorMarkerTest.class);
 
 		/* model tests */
 		suite.addTestSuite(AssignmentDirectiveTest.class);


### PR DESCRIPTION
Better error markers by utilizing the information available in FreeMarker's ParseException: column numbers, end position, editorMessage.