### PR TITLE
JBIDE-22656: Related tag background becomes misplaced when typing

### DIFF
--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/DocumentProvider.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/DocumentProvider.java
@@ -23,17 +23,18 @@ package org.jboss.ide.eclipse.freemarker.editor;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.DefaultPositionUpdater;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentExtension3;
 import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.TypedRegion;
 import org.eclipse.jface.text.rules.FastPartitioner;
 import org.eclipse.ui.editors.text.FileDocumentProvider;
 import org.jboss.ide.eclipse.freemarker.editor.partitions.PartitionScanner;
 import org.jboss.ide.eclipse.freemarker.editor.partitions.PartitionType;
 import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
-import org.jboss.ide.eclipse.freemarker.lang.ParserUtils;
 import org.jboss.ide.eclipse.freemarker.lang.SyntaxMode;
 
 /**
@@ -43,6 +44,11 @@ public class DocumentProvider extends FileDocumentProvider {
 
 	public static final String FTL_PARTITIONING = "org.jboss.ide.eclipse.freemarker.partitioning";
 
+	/**
+	 * {@link Position} category in the {@link IDocument} used for tracking the positions of the group of related
+	 * directives that the caret is on.
+	 */
+	public static final String RELATED_ITEM_POSITION_CATEGORY = "org.jboss.ide.eclipse.freemarker.relatedItem";
 
 	public DocumentProvider() {
 		super();
@@ -52,6 +58,7 @@ public class DocumentProvider extends FileDocumentProvider {
 	protected IDocument createDocument(Object element) throws CoreException {
 		IDocument document = super.createDocument(element);
 		if (document != null) {
+			// Set up and register partitioner:
 			IDocumentPartitioner partitioner =
 				new FastPartitioner(
 					new PartitionScanner(),
@@ -80,6 +87,10 @@ public class DocumentProvider extends FileDocumentProvider {
 				document.setDocumentPartitioner(partitioner);
 				partitioner.connect(document);
 			}
+			
+			// Set up position category used for keeping track of the related directive highlights:
+			document.addPositionCategory(RELATED_ITEM_POSITION_CATEGORY);
+			document.addPositionUpdater(new DefaultPositionUpdater(RELATED_ITEM_POSITION_CATEGORY));
 		}
 		return document;
 	}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/ReconcilingStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/ReconcilingStrategy.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension4;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITypedRegion;
 import org.eclipse.jface.text.TextUtilities;
@@ -93,10 +94,11 @@ public class ReconcilingStrategy implements IReconcilingStrategy,
 	 * a new {@link ItemSet} in {@link Editor#reconcile(List)}
 	 */
 	private void reconcile() {
-
+		long stamp1 = ((IDocumentExtension4) document).getModificationStamp();
 		List<ITypedRegion> regions = parseRegions();
+		long stamp2 = ((IDocumentExtension4) document).getModificationStamp();
 		if (regions != null) {
-			this.editor.reconcile(regions);
+			this.editor.reconcile(regions, stamp1 == stamp2 ? stamp1 : null);
 		}
 
 	}
@@ -176,6 +178,10 @@ public class ReconcilingStrategy implements IReconcilingStrategy,
 
 	@Override
 	public void setDocument(IDocument document) {
+		if (!(document instanceof IDocumentExtension4)) {
+			throw new IllegalStateException(
+					"Document must implement " + IDocumentExtension4.class.getName() + ".");  //$NON-NLS-1$//$NON-NLS-2$
+		}
 		this.document = document;
 	}
 

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/RelatedItemPosition.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/RelatedItemPosition.java
@@ -1,25 +1,13 @@
-/*
- * JBoss by Red Hat
- * Copyright 2006-2009, Red Hat Middleware, LLC, and individual contributors as indicated
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
- *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- */
-
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
 package org.jboss.ide.eclipse.freemarker.editor;
 
 import org.eclipse.jface.text.Position;

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/RelatedItemPosition.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/RelatedItemPosition.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss by Red Hat
+ * Copyright 2006-2009, Red Hat Middleware, LLC, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ide.eclipse.freemarker.editor;
+
+import org.eclipse.jface.text.Position;
+
+/**
+ * Used for {@link Position}-s in the {@link DocumentProvider#RELATED_ITEM_POSITION_CATEGORY} category.  
+ */
+public class RelatedItemPosition extends Position {
+	
+	private final boolean highlighted;
+
+	public RelatedItemPosition(int offset, int length, boolean highlighted) {
+		super(offset, length);
+		this.highlighted = highlighted;
+	}
+
+	public boolean isHighlighted() {
+		return highlighted;
+	}
+
+}


### PR DESCRIPTION
Changed the way related item highlighting works. Background coloring boundaries are tracked by IDocument Position-s, and are updated from the the result of the asynchronous reconciler (from the ItemSet) only when that catches up with the IDocument content. This fixes the issue where typing into a tag displaces the background coloring of the related tags, because until the UI thread receives the reconciler results (which can be an arbitrary long time if you are continuously typing), IDocument will synchronously move the Position-s for us as the document is modified.