### PR TITLE
JBIDE-22700: Upgarde to FreeMarker 2.3.25

### DIFF
--- a/plugins/org.jboss.ide.eclipse.freemarker/.classpath
+++ b/plugins/org.jboss.ide.eclipse.freemarker/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
-	<classpathentry exported="true" kind="lib" path="lib/freemarker-2.3.24-incubating.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/freemarker-2.3.25-incubating.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/org.jboss.ide.eclipse.freemarker/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.ide.eclipse.freemarker/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.usage;bundle-version="1.0.0";resolution:=optional;x-installation:=greedy
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- lib/freemarker-2.3.24-incubating.jar
+ lib/freemarker-2.3.25-incubating.jar
 Bundle-Vendor: %providerName
 Export-Package: freemarker.core,
  freemarker.template,

--- a/plugins/org.jboss.ide.eclipse.freemarker/build.properties
+++ b/plugins/org.jboss.ide.eclipse.freemarker/build.properties
@@ -6,7 +6,7 @@ bin.includes = plugin.*,\
                License.txt,\
                about.*,\
                jboss_about.png,\
-               lib/freemarker-2.3.24-incubating.jar
+               lib/freemarker-2.3.25-incubating.jar
 src.includes = plugin.*,\
                icons/,\
                License.txt

--- a/plugins/org.jboss.ide.eclipse.freemarker/pom.xml
+++ b/plugins/org.jboss.ide.eclipse.freemarker/pom.xml
@@ -12,7 +12,7 @@
 
 	<packaging>eclipse-plugin</packaging>
 	<properties>
-		<freemarkerVersion>2.3.24-incubating</freemarkerVersion>
+		<freemarkerVersion>2.3.25-incubating</freemarkerVersion>
 	</properties>
 	<build>
 		<plugins>

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Editor.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Editor.java
@@ -508,8 +508,8 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
 				if (null != getFile()) {
 					if (null == fmConfiguration) {
 						fmConfiguration = new Configuration(Configuration.getVersion());
-						fmConfiguration
-								.setTagSyntax(Configuration.AUTO_DETECT_TAG_SYNTAX);
+						fmConfiguration.setTagSyntax(Configuration.AUTO_DETECT_TAG_SYNTAX);
+						fmConfiguration.setTabSize(1);
 					}
 					getFile().deleteMarkers(IMarker.PROBLEM, true,
 							IResource.DEPTH_INFINITE);
@@ -523,8 +523,8 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
 						Template dummy = new Template(getFile().getName(), documentContent, fmConfiguration);
 					} catch (ParseException e) {
 						editor.addProblemMarker(e.getEditorMessage(), e.getLineNumber(),
-						        getOffset(e.getLineNumber(), e.getColumnNumber()),
-                                getOffset(e.getEndLineNumber(), e.getEndColumnNumber()) + 1);
+								getDocument().getLineOffset(e.getLineNumber() - 1) + e.getColumnNumber() - 1,
+								getDocument().getLineOffset(e.getEndLineNumber() - 1) + e.getEndColumnNumber());
 					}
 				}
 			} catch (Exception e) {
@@ -536,31 +536,6 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
                 }
 			}
 		}
-
-		/**
-         * Calculates the offset of the character in the document at the position
-         * given with 1-based line number and 1-based column number.
-         */
-        // TODO: Get rid of this with FM 2.3.25. Just set tab size to 1.
-        private int getOffset(int lineNumber, int columnNumber) throws BadLocationException {
-            IDocument document = getDocument();
-            
-            int currentOffset = document.getLineOffset(lineNumber - 1);
-            // FreeMarker 2.3.24 has accidentally changed the tab size used for AST node column number calculations
-            // from 8 to 1 with a JavaCC upgrade...
-            if (Configuration.getVersion().intValue() == Version.intValueFor(2, 3, 24)) {
-                return currentOffset + (columnNumber - 1);
-            }
-            
-            int currentColumnNumber = 1;
-            while (currentColumnNumber < columnNumber) {
-                // FreeMarker column number assumes tabs of width 8:
-                currentColumnNumber +=
-                        document.getChar(currentOffset) == '\t' ? 8 - (currentColumnNumber - 1) % 8 : 1; 
-                currentOffset++;
-            }
-            return currentOffset;
-        }
 
 	}
 


### PR DESCRIPTION
 As 2.3.25 supports setting the parser's tab size to 1, the offset calculation complication was removed.