### PR TITLE
JBIDE-20512: Indent lines as the last one when hitting enter.

### DIFF
--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Configuration.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Configuration.java
@@ -43,7 +43,7 @@ import org.jboss.ide.eclipse.freemarker.editor.partitions.PartitionType;
  * @author <a href="mailto:joe@binamics.com">Joe Hudson</a>
  */
 public class Configuration extends TextSourceViewerConfiguration {
-
+	
 	private Editor editor;
 
 	public Configuration(IPreferenceStore preferenceStore, Editor editor) {
@@ -53,7 +53,7 @@ public class Configuration extends TextSourceViewerConfiguration {
 
 	@Override
 	public String[] getConfiguredContentTypes(ISourceViewer sourceViewer) {
-		return PartitionType.PARTITION_TYPES;
+		return PartitionType.CONTENT_TYPES;
 	}
 
 	@Override
@@ -71,8 +71,8 @@ public class Configuration extends TextSourceViewerConfiguration {
 			if (scanner != null) {
 				DefaultDamagerRepairer dr = scanner instanceof ExpressionColoringTokenScanner
 						? new PartitionGranulairyDamagerRepairer(scanner) : new DefaultDamagerRepairer(scanner);
-				reconciler.setDamager(dr, partitionType.name());
-				reconciler.setRepairer(dr, partitionType.name());
+				reconciler.setDamager(dr, partitionType.getContentType());
+				reconciler.setRepairer(dr, partitionType.getContentType());
 			}
 		}
 
@@ -109,7 +109,7 @@ public class Configuration extends TextSourceViewerConfiguration {
 		CompletionProcessor completionProcessor = new CompletionProcessor(editor);
 		assistant.setContentAssistProcessor(completionProcessor, IDocument.DEFAULT_CONTENT_TYPE);
 		for (PartitionType partitionType : PartitionType.values()) {
-			assistant.setContentAssistProcessor(completionProcessor, partitionType.name());
+			assistant.setContentAssistProcessor(completionProcessor, partitionType.getContentType());
 		}
 		//FIXME: Add back XML content assist some day
 //		assistant.setContentAssistProcessor(completionProcessor, PartitionScanner.XML_COMMENT);
@@ -147,6 +147,7 @@ public class Configuration extends TextSourceViewerConfiguration {
 
 	@Override
 	public IAutoEditStrategy[] getAutoEditStrategies(ISourceViewer sourceViewer, String contentType) {
-		return super.getAutoEditStrategies(sourceViewer, contentType);
+		return new IAutoEditStrategy[] { SimpleAutoIndentingAutoEditStrategy.INSTANCE };
 	}
+	
 }

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/DocumentProvider.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/DocumentProvider.java
@@ -27,9 +27,7 @@ import org.eclipse.jface.text.DefaultPositionUpdater;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentExtension3;
 import org.eclipse.jface.text.IDocumentPartitioner;
-import org.eclipse.jface.text.ITypedRegion;
 import org.eclipse.jface.text.Position;
-import org.eclipse.jface.text.TypedRegion;
 import org.eclipse.jface.text.rules.FastPartitioner;
 import org.eclipse.ui.editors.text.FileDocumentProvider;
 import org.jboss.ide.eclipse.freemarker.editor.partitions.PartitionScanner;
@@ -59,41 +57,29 @@ public class DocumentProvider extends FileDocumentProvider {
 	protected IDocument createDocument(Object element) throws CoreException {
 		IDocument document = super.createDocument(element);
 		if (document != null) {
-			// Set up and register partitioner:
-			IDocumentPartitioner partitioner =
-				new FastPartitioner(
-					new PartitionScanner(),
-					PartitionType.PARTITION_TYPES) {
-				public ITypedRegion getPartition(int offset, boolean preferOpenPartitions) {
-					ITypedRegion region= getPartition(offset);
-					if (preferOpenPartitions) {
-						if (region.getOffset() == offset && !region.getType().equals(IDocument.DEFAULT_CONTENT_TYPE)) {
-							if (offset > 0) {
-								region= getPartition(offset - 1);
-								if (region.getType().equals(PartitionType.DIRECTIVE_START.name()))
-									return region;
-							}
-							return new TypedRegion(offset, 0, IDocument.DEFAULT_CONTENT_TYPE);
-						}
-					}
-			        return region;
-				}
-				
-			};
-			if (document instanceof IDocumentExtension3) {
-				IDocumentExtension3 docExt3 = (IDocumentExtension3) document;
-				docExt3.setDocumentPartitioner(FTL_PARTITIONING, partitioner);
-				partitioner.connect(document);
-			} else {
-				document.setDocumentPartitioner(partitioner);
-				partitioner.connect(document);
-			}
+			setupDocumentPartitioner(document);
 			
 			// Set up position category used for keeping track of the related directive highlights:
 			document.addPositionCategory(RELATED_ITEM_POSITION_CATEGORY);
 			document.addPositionUpdater(new DefaultPositionUpdater(RELATED_ITEM_POSITION_CATEGORY));
 		}
 		return document;
+	}
+
+	public static void setupDocumentPartitioner(IDocument document) {
+		// Set up and register partitioner:
+		IDocumentPartitioner partitioner =
+			new FastPartitioner(
+				new PartitionScanner(),
+				PartitionType.CONTENT_TYPES);
+		if (document instanceof IDocumentExtension3) {
+			IDocumentExtension3 docExt3 = (IDocumentExtension3) document;
+			docExt3.setDocumentPartitioner(FTL_PARTITIONING, partitioner);
+			partitioner.connect(document);
+		} else {
+			document.setDocumentPartitioner(partitioner);
+			partitioner.connect(document);
+		}
 	}
 
 	public static SyntaxMode findMode(IDocument document) {

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/ReconcilingStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/ReconcilingStrategy.java
@@ -170,7 +170,7 @@ public class ReconcilingStrategy implements IReconcilingStrategy,
 					monitor.worked(index);
 				}
 				ITypedRegion region = TextUtilities.getPartition(doc, DocumentProvider.FTL_PARTITIONING, index, false);
-				PartitionType partitionType = PartitionType.fastValueOf(region.getType());
+				PartitionType partitionType = PartitionType.getByContentType(region.getType());
 				if (partitionType != null) {
 					ITokenScanner scanner = itemParsers.get(partitionType);
 					if (scanner != null) {

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/SimpleAutoIndentingAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/SimpleAutoIndentingAutoEditStrategy.java
@@ -1,0 +1,69 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IAutoEditStrategy;
+import org.eclipse.jface.text.IDocument;
+import org.jboss.ide.eclipse.freemarker.Plugin;
+
+/**
+ * When pressing enter, indents the new line with the indentation of the current
+ * line.
+ */
+public class SimpleAutoIndentingAutoEditStrategy implements IAutoEditStrategy {
+
+	public static final SimpleAutoIndentingAutoEditStrategy INSTANCE = new SimpleAutoIndentingAutoEditStrategy();
+	
+	private SimpleAutoIndentingAutoEditStrategy() {
+		//
+	}
+	
+	@Override
+	public void customizeDocumentCommand(IDocument document, DocumentCommand command) {
+		try {
+			if (isLineDelimiter(command.text, document)) {
+				command.text = command.text + getIndentationOfLine(document.getLineOfOffset(command.offset), document);
+			}
+		} catch (BadLocationException e) {
+			Plugin.log(e);
+		}
+	}
+
+	protected String getIndentationOfLine(int line, IDocument document) throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		int docLength = document.getLength();
+		int indentationStartOffset = offset;
+		while (offset < docLength && isIndentationCharacter(document.getChar(offset))) {
+			offset++;
+		}
+		return document.get(indentationStartOffset, offset - indentationStartOffset);
+	}
+
+	protected boolean isIndentationCharacter(char c) {
+		return c == ' ' || c == '\t';
+	}
+
+	protected boolean isLineDelimiter(String text, IDocument document) {
+		if (text == null) {
+			return false;
+		}
+
+		for (String lineDelimiter : document.getLegalLineDelimiters()) {
+			if (text.equals(lineDelimiter)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/CommentPartitionRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/CommentPartitionRule.java
@@ -36,7 +36,8 @@ import org.jboss.ide.eclipse.freemarker.lang.SyntaxMode;
 public class CommentPartitionRule extends MultiLineRule implements SyntaxModeListener {
 
 	public CommentPartitionRule() {
-		super(SyntaxMode.getDefault().getCommentStart(), SyntaxMode.getDefault().getCommentEnd(), new Token(PartitionType.COMMENT.name()));
+		super(SyntaxMode.getDefault().getCommentStart(), SyntaxMode.getDefault().getCommentEnd(),
+				new Token(PartitionType.COMMENT.getContentType()));
 	}
 
 	/**

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/DirectiveEndPartitionRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/DirectiveEndPartitionRule.java
@@ -32,7 +32,7 @@ import org.jboss.ide.eclipse.freemarker.lang.SyntaxMode;
 public class DirectiveEndPartitionRule extends GenericDirectiveEndPartitionRule {
 
 	public DirectiveEndPartitionRule() {
-		super(SyntaxMode.getDefault().getDirectiveEnd(), new Token(PartitionType.DIRECTIVE_END.name()));
+		super(SyntaxMode.getDefault().getDirectiveEnd(), new Token(PartitionType.DIRECTIVE_END.getContentType()));
 	}
 
 	@Override

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/DirectiveStartPartitionRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/DirectiveStartPartitionRule.java
@@ -31,7 +31,7 @@ import org.jboss.ide.eclipse.freemarker.lang.SyntaxMode;
  */
 public class DirectiveStartPartitionRule extends GenericDirectiveStartPartitionRule {
 	
-	private static final Token SUCCESS_TOKEN = new Token(PartitionType.DIRECTIVE_START.name());
+	private static final Token SUCCESS_TOKEN = new Token(PartitionType.DIRECTIVE_START.getContentType());
 
 	public DirectiveStartPartitionRule() {
 		super(getStartSequence(SyntaxMode.getDefault()));

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/DollarInterpolationRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/DollarInterpolationRule.java
@@ -16,7 +16,7 @@ import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
 
 public class DollarInterpolationRule extends GenericInterpolationRule {
 
-	private static final Token SUCCESS_TOKEN = new Token(PartitionType.DOLLAR_INTERPOLATION.name());
+	private static final Token SUCCESS_TOKEN = new Token(PartitionType.DOLLAR_INTERPOLATION.getContentType());
 
 	@Override
 	public IToken getSuccessToken() {

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/HashInterpolationRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/HashInterpolationRule.java
@@ -16,7 +16,7 @@ import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
 
 public class HashInterpolationRule extends GenericInterpolationRule {
 
-	private static final Token SUCCESS_TOKEN = new Token(PartitionType.HASH_INTERPOLATION.name());
+	private static final Token SUCCESS_TOKEN = new Token(PartitionType.HASH_INTERPOLATION.getContentType());
 
 	@Override
 	public IToken getSuccessToken() {

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/MacroInstanceEndPartitionRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/MacroInstanceEndPartitionRule.java
@@ -36,7 +36,8 @@ import org.jboss.ide.eclipse.freemarker.lang.SyntaxMode;
 public class MacroInstanceEndPartitionRule extends MultiLineRule implements SyntaxModeListener {
 
 	public MacroInstanceEndPartitionRule() {
-		super(SyntaxMode.getDefault().getMacroInstanceEnd(), SyntaxMode.getDefault().getTagEnd(), new Token(PartitionType.MACRO_INSTANCE_END.name()));
+		super(SyntaxMode.getDefault().getMacroInstanceEnd(), SyntaxMode.getDefault().getTagEnd(),
+				new Token(PartitionType.MACRO_INSTANCE_END.getContentType()));
 	}
 
 	@Override

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/MacroInstanceStartPartitionRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/MacroInstanceStartPartitionRule.java
@@ -31,7 +31,7 @@ import org.jboss.ide.eclipse.freemarker.lang.SyntaxMode;
  */
 public class MacroInstanceStartPartitionRule extends GenericDirectiveStartPartitionRule {
 	
-	private static final Token SUCCESS_TOKEN = new Token(PartitionType.MACRO_INSTANCE_START.name());
+	private static final Token SUCCESS_TOKEN = new Token(PartitionType.MACRO_INSTANCE_START.getContentType());
 
 	public MacroInstanceStartPartitionRule() {
 		super(getStartSequence(SyntaxMode.getDefault()));

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/PartitionScanner.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/PartitionScanner.java
@@ -84,7 +84,7 @@ public class PartitionScanner implements IPartitionTokenScanner, SyntaxModeListe
 			}
 		}
 		setPredicateRules(rules.toArray(new IPredicateRule[rules.size()]));
-		this.defaultReturnToken = new Token(PartitionType.TEXT.name());
+		this.defaultReturnToken = new Token(PartitionType.TEXT.getContentType());
 		this.delegate.setDefaultReturnToken(defaultReturnToken);
 
 	}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/PartitionType.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/PartitionType.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IRule;
@@ -57,13 +58,13 @@ import org.jboss.ide.eclipse.freemarker.target.TargetColoringScanner;
  * @since 1.4.0
  */
 public enum PartitionType {
-	COMMENT(PreferenceKey.COLOR_COMMENT) {
+	COMMENT("ftl.comment", PreferenceKey.COLOR_COMMENT) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			return new CommentPartitionRule();
 		}
 	},
-	DOLLAR_INTERPOLATION(PreferenceKey.COLOR_INTERPOLATION) {
+	DOLLAR_INTERPOLATION("ftl.dollarInterpolation", PreferenceKey.COLOR_INTERPOLATION) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			return new DollarInterpolationRule();
@@ -72,12 +73,12 @@ public enum PartitionType {
 		@Override
 		public ITokenScanner createColoringTokenizer(Editor editor) {
 			return new ExpressionColoringTokenScanner(
-					createColoringToken(foregroundPreferenceKey), false,
+					createColoringToken(getForegroundPreferenceKey()), false,
 					LexicalConstants.DOLLAR_INTERPOLATION_START, LexicalConstants.DOLLAR_INTERPOLATION_END, null, false,
 					null, null, null);
 		}
 	},
-	HASH_INTERPOLATION(PreferenceKey.COLOR_INTERPOLATION) {
+	HASH_INTERPOLATION("ftl.hashInterpolation", PreferenceKey.COLOR_INTERPOLATION) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			return new HashInterpolationRule();
@@ -86,12 +87,12 @@ public enum PartitionType {
 		@Override
 		public ITokenScanner createColoringTokenizer(Editor editor) {
 			return new ExpressionColoringTokenScanner(
-					createColoringToken(foregroundPreferenceKey), false,
+					createColoringToken(getForegroundPreferenceKey()), false,
 					LexicalConstants.HASH_INTERPOLATION_START, LexicalConstants.HASH_INTERPOLATION_END, null, false,
 					null, null, null);
 		}
 	},
-	DIRECTIVE_START(PreferenceKey.COLOR_DIRECTIVE) {
+	DIRECTIVE_START("ftl.directiveStart", PreferenceKey.COLOR_DIRECTIVE) { //$NON-NLS-1$
 		@Override
 		public RuleBasedScanner createItemParser() {
     		List<IRule> rules = new ArrayList<IRule>();
@@ -113,7 +114,7 @@ public enum PartitionType {
 
 		@Override
 		public ITokenScanner createColoringTokenizer(Editor editor) {
-			IToken coloringToken = createColoringToken(foregroundPreferenceKey);
+			IToken coloringToken = createColoringToken(getForegroundPreferenceKey());
 			return new ExpressionColoringTokenScanner(
 					coloringToken, true,
 					LexicalConstants.DIRECTIVE_START_AB, LexicalConstants.DIRECTIVE_END_AB,
@@ -123,7 +124,7 @@ public enum PartitionType {
 		}
 
 	},
-	DIRECTIVE_END(PreferenceKey.COLOR_DIRECTIVE) {
+	DIRECTIVE_END("ftl.directiveEnd", PreferenceKey.COLOR_DIRECTIVE) { //$NON-NLS-1$
 		@Override
 		public RuleBasedScanner createItemParser() {
 
@@ -144,8 +145,7 @@ public enum PartitionType {
 			return new DirectiveEndPartitionRule();
 		}
 	},
-	MACRO_INSTANCE_START(PreferenceKey.COLOR_DIRECTIVE) {
-
+	MACRO_INSTANCE_START("ftl.macroInstanceStart", PreferenceKey.COLOR_DIRECTIVE) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			return new MacroInstanceStartPartitionRule();
@@ -154,20 +154,21 @@ public enum PartitionType {
 		@Override
 		public ITokenScanner createColoringTokenizer(Editor editor) {
 			return new ExpressionColoringTokenScanner(
-					createColoringToken(foregroundPreferenceKey), true,
+					createColoringToken(getForegroundPreferenceKey()), true,
 					LexicalConstants.MACRO_INST_START_AB, LexicalConstants.MACRO_INST_END_AB,
 					LexicalConstants.MACRO_INST_END_AB_EMPTY, true,
 					LexicalConstants.MACRO_INST_START_SB, LexicalConstants.MACRO_INST_END_SB,
 					LexicalConstants.MACRO_INST_END_SB_EMPTY);
 		}
 	},
-	MACRO_INSTANCE_END(PreferenceKey.COLOR_DIRECTIVE) {
+	MACRO_INSTANCE_END("ftl.macroInstanceEnd", PreferenceKey.COLOR_DIRECTIVE) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			return new MacroInstanceEndPartitionRule();
 		}
 	},
-	TEXT(PreferenceKey.COLOR_TEXT) {
+	// IDocument.DEFAULT_CONTENT_TYPE is used to be compatible with FastPartitioner
+	TEXT(IDocument.DEFAULT_CONTENT_TYPE, PreferenceKey.COLOR_TEXT) {
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			/* there is no explicit rule for FTL text */
@@ -180,23 +181,23 @@ public enum PartitionType {
 		}
 
 	};
-
+	
 	/** Partitions as a static array for convenience. */
-	public static final String[] PARTITION_TYPES;
+	public static final String[] CONTENT_TYPES;
 
-	/** Used in {@link #fastValueOf(String)} */
-	private static final Map<String, PartitionType> FAST_LOOKUP;
+	/** Used in {@link #getByContentType(String)} */
+	private static final Map<String, PartitionType> LOOKUP_BY_CONTENT_TYPE;
 
 	static {
 		PartitionType[] partitionTypes = PartitionType.values();
-		PARTITION_TYPES = new String[partitionTypes.length];
-		Map<String, PartitionType> fastLookUp = new HashMap<String, PartitionType>();
+		CONTENT_TYPES = new String[partitionTypes.length];
+		Map<String, PartitionType> lookUpByContentType = new HashMap<String, PartitionType>();
 		for (int i = 0; i < partitionTypes.length; i++) {
 			PartitionType partitionType = partitionTypes[i];
-			PARTITION_TYPES[i] = partitionType.name();
-			fastLookUp.put(partitionType.name(), partitionType);
+			CONTENT_TYPES[i] = partitionType.getContentType();
+			lookUpByContentType.put(partitionType.getContentType(), partitionType);
 		}
-		FAST_LOOKUP = Collections.unmodifiableMap(fastLookUp);
+		LOOKUP_BY_CONTENT_TYPE = Collections.unmodifiableMap(lookUpByContentType);
 	}
 
 	public static IToken createColoringToken(PreferenceKey foregroundPreferenceKey) {
@@ -208,18 +209,21 @@ public enum PartitionType {
 	 * A {@link HashMap}-backed and {@code null}-tolerant alternative of
 	 * {@link #valueOf(String)}.
 	 *
-	 * @param name
+	 * @param contentType
 	 * @return the {@link PartitionType} that corresponds to the given {@code name}
 	 *         or {@code null} of there is no such.
 	 */
-	public static PartitionType fastValueOf(String name) {
-		return FAST_LOOKUP.get(name);
+	public static PartitionType getByContentType(String contentType) {
+		return LOOKUP_BY_CONTENT_TYPE.get(contentType);
 	}
+	
+	private final String contentType;
 
 	/** The preference key for syntax coloring. */
-	final PreferenceKey foregroundPreferenceKey;
+	private final PreferenceKey foregroundPreferenceKey;
 
-	private PartitionType(PreferenceKey foregroundPreferenceKey) {
+	private PartitionType(String contentType, PreferenceKey foregroundPreferenceKey) {
+		this.contentType = contentType;
 		this.foregroundPreferenceKey = foregroundPreferenceKey;
 	}
 
@@ -250,6 +254,14 @@ public enum PartitionType {
 	 */
 	public ITokenScanner createItemParser() {
 		return null;
+	}
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public PreferenceKey getForegroundPreferenceKey() {
+		return foregroundPreferenceKey;
 	}
 
 }

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/rules/DirectiveRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/rules/DirectiveRule.java
@@ -29,7 +29,7 @@ import org.jboss.ide.eclipse.freemarker.lang.SyntaxMode;
 import org.jboss.ide.eclipse.freemarker.model.ItemSet;
 
 /**
- * Matches a particular FTL directive start and marks the region with as the
+ * Matches a particular FTL directive start and marks the region with
  * given {@link Directive#name()}. Used for building an {@link ItemSet}.
  */
 public class DirectiveRule extends GenericDirectiveStartPartitionRule {

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/model/ItemFactory.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/model/ItemFactory.java
@@ -37,13 +37,13 @@ public class ItemFactory {
 		}
 		else {
 			Item directive = null;
-			String type = region.getType();
-			Directive directiveType = Directive.fastValueOf(type);
+			String contentType = region.getType();
+			Directive directiveType = Directive.fastValueOf(contentType);
 			if (directiveType != null) {
 				directive = directiveType.createModelItem(itemSet);
 			}
 			else {
-				PartitionType partitionType = PartitionType.fastValueOf(type);
+				PartitionType partitionType = PartitionType.getByContentType(contentType);
 				switch (partitionType) {
 				case DOLLAR_INTERPOLATION:
 				case HASH_INTERPOLATION:

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/TargetColoringScanner.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/TargetColoringScanner.java
@@ -76,15 +76,15 @@ public class TargetColoringScanner implements ITokenScanner {
 	 * Returns a coloring scanner responsible for the given
 	 * {@code partitionType} of the target language.
 	 *
-	 * @param partitionType the target language partition type
+	 * @param partitionContentType the target language partition type
 	 * @return see above
 	 */
-	private ITokenScanner getColoringScanner(String partitionType) {
-		ITokenScanner result = coloringScanners.get(partitionType);
+	private ITokenScanner getColoringScanner(String partitionContentType) {
+		ITokenScanner result = coloringScanners.get(partitionContentType);
 		if (result == null) {
 			ensureInitialized();
-			result = targetLanguageSupport.createColoringScanner(partitionType);
-			coloringScanners.put(partitionType, result);
+			result = targetLanguageSupport.createColoringScanner(partitionContentType);
+			coloringScanners.put(partitionContentType, result);
 		}
 		return result;
 	}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/txt/TxtSupport.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/txt/TxtSupport.java
@@ -42,7 +42,7 @@ public class TxtSupport implements TargetLanguageSupport {
 	@Override
 	public TargetPartitionScanner createPartitionScanner() {
 		RuleBasedTargetPartitionScanner result = new RuleBasedTargetPartitionScanner();
-		result.setDefaultReturnToken(new Token(PartitionType.TEXT.name()));
+		result.setDefaultReturnToken(new Token(PartitionType.TEXT.getContentType()));
 		return result;
 	}
 

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/xml/XmlPartitionType.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/xml/XmlPartitionType.java
@@ -45,22 +45,22 @@ import org.jboss.ide.eclipse.freemarker.target.TargetMultiLineRule;
  * @since 1.4.0
  */
 public enum XmlPartitionType {
-	COMMENT(PreferenceKey.COLOR_XML_COMMENT) {
+	COMMENT("xml.comment", PreferenceKey.COLOR_XML_COMMENT) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			return new TargetMultiLineRule(
 					XmlLexicalConstants.XML_COMMENT_START,
 					XmlLexicalConstants.XML_COMMENT_END,
-					new Token(this.name()), (char) 0, true);
+					new Token(this.getContentType()), (char) 0, true);
 		}
 	},
-	TAG(PreferenceKey.COLOR_XML_TAG) {
+	TAG("xml.tag", PreferenceKey.COLOR_XML_TAG) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
-			return new XmlTagRule(new Token(this.name()));
+			return new XmlTagRule(new Token(getContentType()));
 		}
 	},
-	OTHER(PreferenceKey.COLOR_TEXT) {
+	OTHER("xml.text", PreferenceKey.COLOR_TEXT) { //$NON-NLS-1$
 		@Override
 		public IPredicateRule createPartitioningRule() {
 			/* no explicit rule for OTHER */
@@ -68,22 +68,25 @@ public enum XmlPartitionType {
 		}
 	};
 
+	private final String contentType;
+	
 	/** The preference key for syntax coloring. */
-	final PreferenceKey foregroundPreferenceKey;
+	private final PreferenceKey foregroundPreferenceKey;
 
-	/** See {@link #fastValueOf(String)} */
-	private static final Map<String, XmlPartitionType> FAST_LOOKUP;
+	/** See {@link #getByContentType(String)} */
+	private static final Map<String, XmlPartitionType> LOOKUP_BY_CONTENT_TYPE;
 
 	static {
 		XmlPartitionType[] partitionTypes = XmlPartitionType.values();
-		Map<String, XmlPartitionType> fastLookUp = new HashMap<String, XmlPartitionType>();
+		Map<String, XmlPartitionType> lookupByContentType = new HashMap<String, XmlPartitionType>();
 		for (XmlPartitionType partitionType : partitionTypes) {
-			fastLookUp.put(partitionType.name(), partitionType);
+			lookupByContentType.put(partitionType.getContentType(), partitionType);
 		}
-		FAST_LOOKUP = Collections.unmodifiableMap(fastLookUp);
+		LOOKUP_BY_CONTENT_TYPE = Collections.unmodifiableMap(lookupByContentType);
 	}
 
-	private XmlPartitionType(PreferenceKey foregroundPreferenceKey) {
+	private XmlPartitionType(String contentType, PreferenceKey foregroundPreferenceKey) {
+		this.contentType = contentType;
 		this.foregroundPreferenceKey = foregroundPreferenceKey;
 	}
 
@@ -114,7 +117,17 @@ public enum XmlPartitionType {
 	 * @return the {@link XmlPartitionType} that corresponds to the given
 	 *         {@code name} or {@code null} of there is no such.
 	 */
-	public static XmlPartitionType fastValueOf(String name) {
-		return FAST_LOOKUP.get(name);
+	public static XmlPartitionType getByContentType(String name) {
+		return LOOKUP_BY_CONTENT_TYPE.get(name);
 	}
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public PreferenceKey getForegroundPreferenceKey() {
+		return foregroundPreferenceKey;
+	}
+	
+	
 }

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/xml/XmlSupport.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/target/xml/XmlSupport.java
@@ -65,8 +65,8 @@ public class XmlSupport implements TargetLanguageSupport {
 	 * @see org.jboss.ide.eclipse.freemarker.target.TargetLanguageSupport#createColoringScanner(java.lang.String)
 	 */
 	@Override
-	public ITokenScanner createColoringScanner(String partitionType) {
-		XmlPartitionType xmlPartitionType = XmlPartitionType.fastValueOf(partitionType);
+	public ITokenScanner createColoringScanner(String partitionContentType) {
+		XmlPartitionType xmlPartitionType = XmlPartitionType.getByContentType(partitionContentType);
 		if (xmlPartitionType != null) {
 			return xmlPartitionType.createColoringTokenizer();
 		}
@@ -88,7 +88,7 @@ public class XmlSupport implements TargetLanguageSupport {
 			}
 		}
 		RuleBasedTargetPartitionScanner result = new RuleBasedTargetPartitionScanner();
-		result.setDefaultReturnToken(new Token(XmlPartitionType.OTHER.name()));
+		result.setDefaultReturnToken(new Token(XmlPartitionType.OTHER.getContentType()));
 		result.setPredicateRules(rules.toArray(new IPredicateRule[rules.size()]));
 		return result;
 	}

--- a/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/AutoEditStrategyTest.java
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/AutoEditStrategyTest.java
@@ -1,0 +1,98 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/ 
+package org.jboss.ide.eclipse.freemarker.editor.test;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IAutoEditStrategy;
+import org.eclipse.jface.text.IDocument;
+import org.jboss.ide.eclipse.freemarker.editor.DocumentProvider;
+import org.jboss.ide.eclipse.freemarker.editor.SimpleAutoIndentingAutoEditStrategy;
+import org.jboss.ide.eclipse.freemarker.editor.partitions.PartitionScanner;
+import org.junit.Assert;
+
+import junit.framework.TestCase;
+
+public class AutoEditStrategyTest extends TestCase {
+	
+	private IDocument document = new Document();
+	private int caretOffset;
+	private IAutoEditStrategy autoEditStrategy;
+	
+	public void setUp() {
+		DocumentProvider.setupDocumentPartitioner(document);
+	}
+	
+	public void testSimpleAutoIndent() throws BadLocationException {
+		autoEditStrategy = SimpleAutoIndentingAutoEditStrategy.INSTANCE;
+		
+		document.set(" \t foo");
+		moveCaretToEnd();
+		type("\nx");
+		Assert.assertEquals(" \t foo\n \t x", document.get());
+
+		document.set(" ");
+		moveCaretToEnd();
+		type("\nx");
+		Assert.assertEquals(" \n x", document.get());
+		
+		document.set("");
+		moveCaretToEnd();
+		type("\nx");
+		Assert.assertEquals("\nx", document.get());
+		
+		document.set("");
+		moveCaretToEnd();
+		type("x");
+		Assert.assertEquals("x", document.get());
+	}
+
+	private void moveCaretToEnd() {
+		caretOffset = document.getLength();
+	}
+
+	private void type(String s) throws BadLocationException {
+		for (int i = 0; i < s.length(); i++) {
+			type(s.charAt(i));
+		}
+	}
+	
+	private void type(char c) throws BadLocationException {
+		if (autoEditStrategy == null) {
+			throw new IllegalStateException("The JUnit test didn't set the autoEditStrategy field!");
+		}
+		
+		DocumentCommand cmd = createTypingCommand(String.valueOf(c));
+		autoEditStrategy.customizeDocumentCommand(document, cmd);
+		document.replace(cmd.offset, cmd.length, cmd.text);
+		if (cmd.shiftsCaret) {
+			caretOffset += cmd.text.length();
+		} else {
+			caretOffset = cmd.offset; // Should I do this? 
+		}
+	}
+	
+	private DocumentCommand createTypingCommand(String text) {
+		if (caretOffset > document.getLength()) {
+			caretOffset = document.getLength();
+		}
+		DocumentCommand cmd = new DocumentCommand() { /* to access protected constructor */ };
+		cmd.offset = caretOffset;
+		cmd.length = 0;
+		cmd.text = text;
+		cmd.doit = true;
+		cmd.shiftsCaret = true;
+		cmd.caretOffset = caretOffset;		
+		return cmd;
+	}
+
+}

--- a/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/ExpectedTokenList.java
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/ExpectedTokenList.java
@@ -52,7 +52,7 @@ public class ExpectedTokenList {
 	}
 	
 	public ExpectedTokenList add(PartitionType partitionType, int length) {
-		expectedTokens.add(new TokenAssertion(nextOffset, length, partitionType.name()));
+		expectedTokens.add(new TokenAssertion(nextOffset, length, partitionType.getContentType()));
 		nextOffset += length;
 		return this;
 	}

--- a/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/test/FreemarkerAllTests.java
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/test/FreemarkerAllTests.java
@@ -16,6 +16,7 @@ import org.jboss.ide.eclipse.freemarker.editor.coloring.test.StringLiteralsColor
 import org.jboss.ide.eclipse.freemarker.editor.test.FreemarkerEditorTest;
 import org.jboss.ide.eclipse.freemarker.editor.test.IncludeHyperlinkDetectorTest;
 import org.jboss.ide.eclipse.freemarker.editor.test.PartitionScannerTest;
+import org.jboss.ide.eclipse.freemarker.editor.test.AutoEditStrategyTest;
 import org.jboss.ide.eclipse.freemarker.editor.test.ErrorMarkerTest;
 import org.jboss.ide.eclipse.freemarker.lang.test.ParserUtilsTest;
 import org.jboss.ide.eclipse.freemarker.model.test.AssignmentDirectiveTest;
@@ -35,6 +36,7 @@ public class FreemarkerAllTests extends TestCase {
 	    suite.addTestSuite(ErrorMarkerTest.class);
 		suite.addTestSuite(PartitionScannerTest.class);
 		suite.addTestSuite(FreemarkerPreferencePageTest.class);
+		suite.addTestSuite(AutoEditStrategyTest.class);
 
 		// model tests
 		suite.addTestSuite(AssignmentDirectiveTest.class);


### PR DESCRIPTION
Also, using content type IDocument.DEFAULT_CONTENT_TYPE for PartitionType.TEXT partitions instead of "TEXT", because FastPartitioner sometimes has generated IDocument.DEFAULT_CONTENT_TYPE  instead of "TEXT" content type, to which our IAutoEditingStrategy wasn't associated. So now partition type enums have a getContentType() method, and we use the result of that as partition content type instead of Enumeration.name().