### PR TITLE
JBIDE-22749: Added/fixed the automatic insertion of the closing ">" or "}" or "]" or "-->" or "--]".

### DIFF
--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Editor.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/Editor.java
@@ -43,7 +43,6 @@ import org.eclipse.jface.text.ITypedRegion;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.MatchingCharacterPainter;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
@@ -61,7 +60,6 @@ import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.jboss.ide.eclipse.freemarker.Plugin;
 import org.jboss.ide.eclipse.freemarker.configuration.ConfigurationManager;
 import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
-import org.jboss.ide.eclipse.freemarker.lang.ParserUtils;
 import org.jboss.ide.eclipse.freemarker.model.Item;
 import org.jboss.ide.eclipse.freemarker.model.ItemSet;
 import org.jboss.ide.eclipse.freemarker.outline.OutlinePage;
@@ -86,7 +84,6 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
 	private boolean readOnly = false;
 
 	private boolean mouseDown = false;
-	private boolean shiftDown = false;
 
 	public Editor() {
 		super();
@@ -177,6 +174,18 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
 
 	@Override
 	public void mouseDoubleClick(MouseEvent e) {
+		// Nothing to do
+	}
+	
+
+	@Override
+	public void keyPressed(KeyEvent e) {
+		// Nothing to do
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e) {
+		// Nothing to do
 	}
 
 	@Override
@@ -427,88 +436,6 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
 		return fOutlinePage;
 	}
 
-	@Override
-	public void keyPressed(KeyEvent e) {
-		if (e.keyCode == SWT.SHIFT) {
-			shiftDown = true;
-		}
-		// this feature is for avoiding double closing brackets 
-		if (e.character == LexicalConstants.RIGHT_SQUARE_BRACKET 
-						|| e.character == LexicalConstants.RIGHT_BRACE ) {
-			try {
-				int offset = getCaretOffset();
-				if (offset < getDocument().getLength()) {
-					char c = getDocument().getChar(offset);
-					if (c == e.character) {
-						// remove this
-						getDocument().replace(getCaretOffset(), 1, ""); //$NON-NLS-1$
-					}
-				}
-			} catch (BadLocationException e1) {
-				Plugin.log(e1);
-			}
-		}
-	}
-
-	@Override
-	public void keyReleased(KeyEvent e) {
-		if (e.keyCode == SWT.SHIFT) {
-			shiftDown = false;
-		}
-		try {
-			IDocument document = getSourceViewer().getDocument();
-			if (shiftDown && (e.keyCode == '3' || e.keyCode == '2')) {
-				int offset = getCaretOffset();
-				char c = document.getChar(offset - 2);
-				if (c == LexicalConstants.LEFT_SQUARE_BRACKET
-						|| c == LexicalConstants.LEFT_ANGLE_BRACKET) {
-					// directive
-					char endChar = ParserUtils.getMatchingRightBracket(c);
-					if (document.getLength() > offset) {
-						if (offset > 0) {
-							for (int i = offset + 1; i < document.getLength(); i++) {
-								char c2 = document.getChar(i);
-								if (c2 == endChar) {
-									return;
-								} else if (c2 == LexicalConstants.LF) {
-									break;
-								}
-							}
-							document.replace(offset, 0, String.valueOf(endChar));
-						}
-					} else {
-						document.replace(offset, 0, String.valueOf(endChar));
-					}
-				}
-			} else if (shiftDown && e.keyCode == LexicalConstants.LEFT_BRACE) {
-				int offset = getCaretOffset();
-				char c = document.getChar(offset - 2);
-				if (c == LexicalConstants.DOLLAR) {
-					// interpolation
-					if (document.getLength() > offset) {
-						if (offset > 0) {
-							for (int i = offset + 1; i < document.getLength(); i++) {
-								char c2 = document.getChar(i);
-								if (c2 == LexicalConstants.RIGHT_BRACE) {
-									return;
-								} else if (c2 == LexicalConstants.LF) {
-									break;
-								}
-							}
-							document.replace(offset, 0, String
-									.valueOf(LexicalConstants.RIGHT_BRACE));
-						}
-					} else {
-						document.replace(offset, 0,
-								String.valueOf(LexicalConstants.RIGHT_BRACE));
-					}
-				}
-			}
-		} catch (BadLocationException exc) {
-			Plugin.log(exc);
-		}
-	}
-
 	public IProject getProject() {
 		return ((IFileEditorInput) getEditorInput()).getFile().getProject();
 	}
@@ -618,4 +545,5 @@ public class Editor extends TextEditor implements KeyListener, MouseListener {
 		}
 		return targetLanguageSupport;
 	}
+	
 }

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/AbstractSingeTypedCharacterAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/AbstractSingeTypedCharacterAutoEditStrategy.java
@@ -1,0 +1,49 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
+
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IAutoEditStrategy;
+import org.eclipse.jface.text.IDocument;
+import org.jboss.ide.eclipse.freemarker.Plugin;
+
+public abstract class AbstractSingeTypedCharacterAutoEditStrategy implements IAutoEditStrategy {
+
+	protected void replacedTypedCharWithString(DocumentCommand command, String replacement) {
+		command.text = replacement;
+		command.caretOffset = command.offset + 1;
+		command.shiftsCaret = false;
+	}
+
+	@Override
+	public final void customizeDocumentCommand(IDocument document, DocumentCommand command) {
+		if (command.length == 0 && command.text != null && command.text.length() == 1) {
+			try {
+				char typedC = command.text.charAt(0);
+				if (prefilterTypedCharacter(typedC)) {
+					customizeDocumentCommand(document, command, typedC);
+				}
+			} catch (Exception e) {
+				Plugin.log(e);
+			}
+		}
+	}
+	
+	protected abstract void customizeDocumentCommand(IDocument document, DocumentCommand command, char typedC)
+			throws Exception;
+	
+	/**
+	 * Can be used for a rough, first round filtering. Returning {@code true} isn't binding, as you can still left
+	 * the command unmodified.
+	 */
+	protected abstract boolean prefilterTypedCharacter(char typedC); 
+
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/AutoEditUtils.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/AutoEditUtils.java
@@ -1,0 +1,54 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.BadPartitioningException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.ITypedRegion;
+import org.jboss.ide.eclipse.freemarker.Plugin;
+import org.jboss.ide.eclipse.freemarker.editor.DocumentProvider;
+import org.jboss.ide.eclipse.freemarker.editor.partitions.PartitionType;
+
+public final class AutoEditUtils {
+
+	private AutoEditUtils() {
+		//
+	}
+
+	public static int getNextFTLTagOffset(IDocument document, int offset) {
+		IDocumentExtension3 docExt3 = (IDocumentExtension3) document;
+		try {
+			while (offset < document.getLength()) {
+				ITypedRegion partition = docExt3.getPartition(DocumentProvider.FTL_PARTITIONING, offset, false);
+	
+				String contentType = partition.getType();
+				if (contentType.equals(PartitionType.DIRECTIVE_START.getContentType())
+						|| contentType.equals(PartitionType.DIRECTIVE_END.getContentType())
+						|| contentType.equals(PartitionType.MACRO_INSTANCE_START.getContentType())
+						|| contentType.equals(PartitionType.MACRO_INSTANCE_END.getContentType())) {
+					return offset;
+				}
+	
+				int partitionLength = partition.getLength();
+				// Partition of length 0 shouldn't occur here, but don't stuck
+				// in an infinite loop if it still does.
+				offset += partitionLength > 0 ? partitionLength : 1;
+			}
+			return -1;
+		} catch (BadLocationException | BadPartitioningException e) {
+			Plugin.log(e);
+			return -1;
+		}
+	}
+	
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/FTLCommentCloserAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/FTLCommentCloserAutoEditStrategy.java
@@ -1,0 +1,70 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
+
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.ITypedRegion;
+import org.jboss.ide.eclipse.freemarker.editor.DocumentProvider;
+import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
+import org.jboss.ide.eclipse.freemarker.lang.ParserUtils;
+
+public class FTLCommentCloserAutoEditStrategy extends AbstractSingeTypedCharacterAutoEditStrategy {
+	
+	public final static FTLCommentCloserAutoEditStrategy INSTANCE = new FTLCommentCloserAutoEditStrategy();
+	
+	private FTLCommentCloserAutoEditStrategy() {
+		//
+	}
+	
+	@Override
+	protected void customizeDocumentCommand(IDocument document, DocumentCommand command, char typedC) throws Exception {
+		final int cmdOffset = command.offset; 
+		
+		final int tagStartOffset;
+		{
+			if (cmdOffset < 3) {
+				return;
+			}
+			if (document.getChar(cmdOffset - 1) != LexicalConstants.MINUS
+					|| document.getChar(cmdOffset - 2) != LexicalConstants.HASH) {
+				return;
+			}
+
+			tagStartOffset = cmdOffset - 3;
+		}
+		
+		ITypedRegion partition = ((IDocumentExtension3) document).getPartition(
+				DocumentProvider.FTL_PARTITIONING, tagStartOffset, false);
+		if (partition.getOffset() != tagStartOffset) {
+			return;
+		}
+		
+		char tagStartC = document.getChar(partition.getOffset());
+		if (tagStartC != LexicalConstants.LEFT_ANGLE_BRACKET && tagStartC != LexicalConstants.LEFT_SQUARE_BRACKET) {
+			// This probably can't happen
+			return;
+		}
+		
+		char tagEndC = ParserUtils.getMatchingRightBracket(tagStartC);
+		replacedTypedCharWithString(command, "-  --"  //$NON-NLS-1$
+				+ (document.getChar(partition.getOffset() + partition.getLength() - 1) == tagEndC
+						? "" : tagEndC)); //$NON-NLS-1$
+		command.caretOffset++; // Skip space after "-"
+	}
+
+	@Override
+	protected boolean prefilterTypedCharacter(char typedC) {
+		return typedC == LexicalConstants.MINUS;
+	}
+
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/FTLTagCloserAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/FTLTagCloserAutoEditStrategy.java
@@ -1,0 +1,79 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
+
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IDocument;
+import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
+import org.jboss.ide.eclipse.freemarker.lang.ParserUtils;
+
+public class FTLTagCloserAutoEditStrategy extends AbstractSingeTypedCharacterAutoEditStrategy {
+	
+	public final static FTLTagCloserAutoEditStrategy INSTANCE = new FTLTagCloserAutoEditStrategy();
+
+	private FTLTagCloserAutoEditStrategy() {
+		//
+	}
+	
+	@Override
+	protected void customizeDocumentCommand(IDocument document, DocumentCommand command, char typedC) throws Exception {
+		final int cmdOffset = command.offset; 
+		
+		final int tagStartOffset;
+		final char tagStartC; // '<' or '['
+		final boolean isEndTag; // like </#
+		{
+			if (cmdOffset < 1) {
+				return;
+			}
+			char c = document.getChar(cmdOffset - 1);
+			isEndTag = c == LexicalConstants.SLASH;
+			if (isEndTag) {
+				if (cmdOffset < 2) {
+					return;
+				}
+				tagStartOffset = cmdOffset - 2;
+				tagStartC = document.getChar(tagStartOffset);
+			} else {
+				tagStartOffset = cmdOffset - 1;
+				tagStartC = c;
+			}
+
+			if (tagStartC != LexicalConstants.LEFT_ANGLE_BRACKET
+					&& tagStartC != LexicalConstants.LEFT_SQUARE_BRACKET) {
+				return;
+			}
+		}
+
+		char tagEndC = ParserUtils.getMatchingRightBracket(tagStartC);
+		
+		// When typing the "#" or "@" into the middle of a "<>", don't make a "<#>>" or "<@>>" out of it.
+		// This happens often when someone types "<#", then backspace, then "@" (or the other way around).
+		if (tagStartOffset + 1 < document.getLength() && document.getChar(tagStartOffset + 1) == tagEndC) {
+			return;
+		}
+		
+		// If the tag syntax is already established, only one of '<' and '[' will count as tag starter,
+		// otherwise both does.
+		int ftlTagOffset = AutoEditUtils.getNextFTLTagOffset(document, 0);
+		if (ftlTagOffset != -1 && document.getChar(ftlTagOffset) != tagStartC) {
+			return;
+		}
+		
+		replacedTypedCharWithString(command, "" + typedC + tagEndC); //$NON-NLS-1$
+	}
+
+	@Override
+	protected boolean prefilterTypedCharacter(char typedC) {
+		return typedC == LexicalConstants.HASH || typedC == LexicalConstants.AT;
+	}
+
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/FTLTagDoubleClosingPreventionAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/FTLTagDoubleClosingPreventionAutoEditStrategy.java
@@ -1,0 +1,68 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
+
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IAutoEditStrategy;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.ITypedRegion;
+import org.jboss.ide.eclipse.freemarker.editor.DocumentProvider;
+import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
+import org.jboss.ide.eclipse.freemarker.lang.ParserUtils;
+
+/**
+ * Suppresses the ">" or "]" typed, when it's going to be inserted before the identical character at the end of
+ * the partition. This can happen because the editor automatically adds the closing ">" or "]", but some may still
+ * instinctively types it.
+ */
+public class FTLTagDoubleClosingPreventionAutoEditStrategy extends AbstractSingeTypedCharacterAutoEditStrategy {
+
+	public static final IAutoEditStrategy INSTANCE = new FTLTagDoubleClosingPreventionAutoEditStrategy();
+	
+	private FTLTagDoubleClosingPreventionAutoEditStrategy() {
+		//
+	}
+
+	@Override
+	protected void customizeDocumentCommand(IDocument document, DocumentCommand command, char typedC) throws Exception {
+		ITypedRegion partition = ((IDocumentExtension3) document)
+				.getPartition(DocumentProvider.FTL_PARTITIONING, command.offset, false);
+		
+		if (partition.getLength() < 2) {
+			return;
+		}
+
+		int lastCharOffset = partition.getOffset() + partition.getLength() - 1;
+		if (command.offset != lastCharOffset) {
+			return;
+		}
+		
+		char tagClosingC;
+		try {
+			tagClosingC = ParserUtils.getMatchingRightBracket(document.getChar(partition.getOffset()));
+		} catch (IllegalArgumentException e) {
+			// Partition didn't start with "<" or "["
+			tagClosingC = 0;
+		}
+		if (typedC == tagClosingC) {
+			command.text = ""; //$NON-NLS-1$
+			command.shiftsCaret = false;
+			command.caretOffset = command.offset + 1;
+		}
+	}
+
+	@Override
+	protected boolean prefilterTypedCharacter(char typedC) {
+		return typedC == LexicalConstants.RIGHT_ANGLE_BRACKET || typedC == LexicalConstants.RIGHT_SQUARE_BRACKET;
+	}
+
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/InterpolationCloserAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/InterpolationCloserAutoEditStrategy.java
@@ -1,0 +1,42 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
+
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IDocument;
+import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
+
+public class InterpolationCloserAutoEditStrategy extends AbstractSingeTypedCharacterAutoEditStrategy {
+	
+	public final static InterpolationCloserAutoEditStrategy INSTANCE = new InterpolationCloserAutoEditStrategy();
+	
+	private InterpolationCloserAutoEditStrategy() {
+		//
+	}
+	
+	@Override
+	protected void customizeDocumentCommand(IDocument document, DocumentCommand command, char typedC) throws Exception {
+		if (command.offset <= 0) {
+			return;
+		}
+		
+		char prevC = document.getChar(command.offset - 1);
+		if (prevC == LexicalConstants.DOLLAR || prevC == LexicalConstants.HASH) {
+			replacedTypedCharWithString(command, "" + typedC + LexicalConstants.RIGHT_BRACE); //$NON-NLS-1$
+		}
+	}
+
+	@Override
+	protected boolean prefilterTypedCharacter(char typedC) {
+		return typedC == LexicalConstants.LEFT_BRACE;
+	}
+
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/InterpolationDoubleClosingPreventionAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/InterpolationDoubleClosingPreventionAutoEditStrategy.java
@@ -1,0 +1,58 @@
+/******************************************************************************* 
+ * Copyright (c) 2015 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Daniel Dekany 
+ ******************************************************************************/
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
+
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IAutoEditStrategy;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.ITypedRegion;
+import org.jboss.ide.eclipse.freemarker.editor.DocumentProvider;
+import org.jboss.ide.eclipse.freemarker.lang.LexicalConstants;
+
+/**
+ * Suppresses the "}" typed, when it's going to be inserted before the identical character at the end of
+ * the partition. This can happen because the editor automatically adds the closing "}", but some may still
+ * instinctively types it.
+ */
+public class InterpolationDoubleClosingPreventionAutoEditStrategy
+		extends AbstractSingeTypedCharacterAutoEditStrategy {
+
+	public static final IAutoEditStrategy INSTANCE = new InterpolationDoubleClosingPreventionAutoEditStrategy();
+	
+	private InterpolationDoubleClosingPreventionAutoEditStrategy() {
+		//
+	}
+	
+	@Override
+	protected void customizeDocumentCommand(IDocument document, DocumentCommand command, char typedC) throws Exception {
+		ITypedRegion partition = ((IDocumentExtension3) document)
+				.getPartition(DocumentProvider.FTL_PARTITIONING, command.offset, false);
+		
+		if (partition.getLength() < 2) {
+			return;
+		}
+		
+		int lastCharOffset = partition.getOffset() + partition.getLength() - 1;
+		
+		if (command.offset == lastCharOffset && document.getChar(lastCharOffset) == LexicalConstants.RIGHT_BRACE) {
+			command.text = ""; //$NON-NLS-1$
+			command.shiftsCaret = false;
+			command.caretOffset = command.offset + 1;
+		}
+	}
+
+	@Override
+	protected boolean prefilterTypedCharacter(char typedC) {
+		return typedC == LexicalConstants.RIGHT_BRACE;
+	}
+
+}

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/SimpleAutoIndentingAutoEditStrategy.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/autoedit/SimpleAutoIndentingAutoEditStrategy.java
@@ -8,7 +8,7 @@
  * Contributors: 
  * Daniel Dekany 
  ******************************************************************************/
-package org.jboss.ide.eclipse.freemarker.editor;
+package org.jboss.ide.eclipse.freemarker.editor.autoedit;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentCommand;

--- a/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/CommentPartitionRule.java
+++ b/plugins/org.jboss.ide.eclipse.freemarker/src/org/jboss/ide/eclipse/freemarker/editor/partitions/CommentPartitionRule.java
@@ -37,7 +37,7 @@ public class CommentPartitionRule extends MultiLineRule implements SyntaxModeLis
 
 	public CommentPartitionRule() {
 		super(SyntaxMode.getDefault().getCommentStart(), SyntaxMode.getDefault().getCommentEnd(),
-				new Token(PartitionType.COMMENT.getContentType()));
+				new Token(PartitionType.COMMENT.getContentType()), (char) 0, true);
 	}
 
 	/**

--- a/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/AutoEditStrategyTest.java
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/AutoEditStrategyTest.java
@@ -10,78 +10,240 @@
  ******************************************************************************/ 
 package org.jboss.ide.eclipse.freemarker.editor.test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.BadPartitioningException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.DocumentCommand;
 import org.eclipse.jface.text.IAutoEditStrategy;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.ITypedRegion;
+import org.jboss.ide.eclipse.freemarker.editor.Configuration;
 import org.jboss.ide.eclipse.freemarker.editor.DocumentProvider;
-import org.jboss.ide.eclipse.freemarker.editor.SimpleAutoIndentingAutoEditStrategy;
-import org.jboss.ide.eclipse.freemarker.editor.partitions.PartitionScanner;
 import org.junit.Assert;
 
 import junit.framework.TestCase;
 
 public class AutoEditStrategyTest extends TestCase {
 	
+	private static final String[] FTL_TAG_PERMUTATIONS = new String[] {null, "<[>]", "#@", "<[>]#@"};
+	private static final String[] INTERPOLATION_PERMUTATIONS = new String[] {null, "$#"};
+	
 	private IDocument document = new Document();
 	private int caretOffset;
-	private IAutoEditStrategy autoEditStrategy;
+	
+	private Map<String, IAutoEditStrategy[]> autoEditStrategiesByContentType
+			= new HashMap<String, IAutoEditStrategy[]>();
+			
+	private String translations;
+
+	public void testBasicTyping() throws Exception {
+		setContentWithCaret("|");
+		type("x");
+		assertContentWithCaret("x|");
+		type("y");
+		assertContentWithCaret("xy|");
+		
+		setContentWithCaret("1|2");
+		type("x");
+		assertContentWithCaret("1x|2");
+		type("y");
+		assertContentWithCaret("1xy|2");
+	}
+			
+	public void testSimpleAutoIndent() throws Exception {
+		setContentWithCaret(" \t foo|");
+		type("\n");
+		assertContentWithCaret(" \t foo\n \t |");
+
+		setContentWithCaret(" |");
+		type("\n");
+		assertContentWithCaret(" \n |");
+		
+		setContentWithCaret("|");
+		type("\n");
+		assertContentWithCaret("\n|");
+		
+		setContentWithCaret("  ${|}");
+		type("\n");
+		assertContentWithCaret("  ${\n  |}");
+		
+		setContentWithCaret("  <#if|>");
+		type("\n");
+		assertContentWithCaret("  <#if\n  |>");
+		
+		setContentWithCaret("  <#-- |-->");
+		type("\n");
+		assertContentWithCaret("  <#-- \n  |-->");
+	}
+
+	public void testInterpolationAutoClosing() throws Exception {
+		for (String translations : INTERPOLATION_PERMUTATIONS) {
+			this.translations = translations;
+			
+			setContentWithCaret("$|");
+			type("{");
+			assertContentWithCaret("${|}");
+		}
+	}
+	
+	public void testInterpolationDoubleClosingPrevention() throws Exception {
+		for (String translations : INTERPOLATION_PERMUTATIONS) {
+			this.translations = translations;
+			
+			setContentWithCaret("${|}");
+			type("}");
+			assertContentWithCaret("${}|");
+			
+			setContentWithCaret("${x|}");
+			type("}");
+			assertContentWithCaret("${x}|");
+			
+			setContentWithCaret("#{x|}");
+			type("}");
+			assertContentWithCaret("#{x}|");
+		}
+	}
+
+	public void testFTLTagAutoClosing() throws Exception {
+		for (String translations : FTL_TAG_PERMUTATIONS) {
+			this.translations = translations;
+			
+			setContentWithCaret("<|");
+			type("#");
+			assertContentWithCaret("<#|>");
+			
+			setContentWithCaret("</|");
+			type("#");
+			assertContentWithCaret("</#|>");
+		}
+		
+		this.translations = null;
+		
+		setContentWithCaret("[#ftl]<|");
+		type("#");
+		assertContentWithCaret("[#ftl]<#|");
+
+		setContentWithCaret("[#ftl][|");
+		type("#");
+		assertContentWithCaret("[#ftl][#|]");
+		
+		setContentWithCaret("<#ftl>[|");
+		type("#");
+		assertContentWithCaret("<#ftl>[#|");
+		
+		setContentWithCaret("<#ftl><|");
+		type("#");
+		assertContentWithCaret("<#ftl><#|>");
+	}
+	
+	public void testFTLTagDoubleClosingPrevention() throws Exception {
+		// TODO Some permutations don't work because DocumentProvider.findMode(IDocument) is broken.
+		// for (String translations : FTL_TAG_PERMUTATIONS) {
+		//     this.translations = translations;
+		
+		setContentWithCaret("<#|>");
+		type(">");
+		assertContentWithCaret("<#>|");
+		
+		setContentWithCaret("<#x|>");
+		type(">");
+		assertContentWithCaret("<#x>|");
+		
+		setContentWithCaret("<#x></#x|>");
+		type(">");
+		assertContentWithCaret("<#x></#x>|");
+		
+		// }
+	}
+
+	public void testFTLCommentClosing() throws Exception {
+		for (String translations : new String[] { null, "<[>]" }) {
+			this.translations = translations;
+			
+			setContentWithCaret("|");
+			type("<#");
+			assertContentWithCaret("<#|>");
+			type("--");
+			assertContentWithCaret("<#-- | -->");
+			
+			setContentWithCaret("<#-|");
+			type("-");
+			assertContentWithCaret("<#-- | -->");
+		}
+	}
+
+	public void testCombined() throws Exception {
+		setContentWithCaret("|");
+		type("<#if x");
+		caretOffset = document.getLength();
+		type("\n  ${y");
+		caretOffset = document.getLength();
+		type("\n<#--foo");
+		caretOffset = document.getLength();
+		type("\n</#if");
+		assertContentWithCaret("<#if x>\n  ${y}\n  <#-- foo -->\n  </#if|>");
+	}
 	
 	public void setUp() {
 		DocumentProvider.setupDocumentPartitioner(document);
+		
+		// We try to mimic what a real Editor does (getting things from the TextSourceViewerConfiguration):
+		for (String contentType : Configuration.getConfiguredContentTypes()) {
+			autoEditStrategiesByContentType.put(contentType, Configuration.getAutoEditStrategies(contentType, true));
+		}
 	}
 	
-	public void testSimpleAutoIndent() throws BadLocationException {
-		autoEditStrategy = SimpleAutoIndentingAutoEditStrategy.INSTANCE;
+	private void setContentWithCaret(String content) {
+		content = translate(content);
 		
-		document.set(" \t foo");
-		moveCaretToEnd();
-		type("\nx");
-		Assert.assertEquals(" \t foo\n \t x", document.get());
-
-		document.set(" ");
-		moveCaretToEnd();
-		type("\nx");
-		Assert.assertEquals(" \n x", document.get());
-		
-		document.set("");
-		moveCaretToEnd();
-		type("\nx");
-		Assert.assertEquals("\nx", document.get());
-		
-		document.set("");
-		moveCaretToEnd();
-		type("x");
-		Assert.assertEquals("x", document.get());
+		caretOffset = content.indexOf('|');
+		if (caretOffset == -1) {
+			throw new IllegalArgumentException("No '|' (caret position mark) in the arugment.");
+		}
+		document.set(content.substring(0, caretOffset) + content.substring(caretOffset + 1));
 	}
-
-	private void moveCaretToEnd() {
-		caretOffset = document.getLength();
-	}
-
-	private void type(String s) throws BadLocationException {
+	
+	/**
+	 * Convenience method for doing a sequence of {@link type(char)} calls.
+	 */
+	private void type(String s) throws BadLocationException, BadPartitioningException {
 		for (int i = 0; i < s.length(); i++) {
 			type(s.charAt(i));
 		}
 	}
-	
-	private void type(char c) throws BadLocationException {
-		if (autoEditStrategy == null) {
-			throw new IllegalStateException("The JUnit test didn't set the autoEditStrategy field!");
+
+	/**
+	 * Emulates typing a single character. Simply calling {@link IDocument#replace(int, int, String)} wouldn't trigger
+	 * the auto edit strategies, but this does.
+	 */
+	private void type(char c) throws BadLocationException, BadPartitioningException {
+		ITypedRegion partition = ((IDocumentExtension3) document).getPartition(
+				DocumentProvider.FTL_PARTITIONING, caretOffset, false);
+		// Avoid the 0-length TEXT-like partition at the end:
+		if (partition.getLength() == 0 && partition.getOffset() > 0) {
+			partition = ((IDocumentExtension3) document).getPartition(
+					DocumentProvider.FTL_PARTITIONING, caretOffset - 1, false);
 		}
 		
-		DocumentCommand cmd = createTypingCommand(String.valueOf(c));
-		autoEditStrategy.customizeDocumentCommand(document, cmd);
-		document.replace(cmd.offset, cmd.length, cmd.text);
-		if (cmd.shiftsCaret) {
-			caretOffset += cmd.text.length();
-		} else {
-			caretOffset = cmd.offset; // Should I do this? 
+		String contentType = partition.getType();
+		IAutoEditStrategy[] autoEditStrategies = autoEditStrategiesByContentType.get(contentType);
+		
+		DocumentCommand cmd = createInsertAtCaretCommand(String.valueOf(c));
+		for (IAutoEditStrategy autoEditStrategy : autoEditStrategies) {
+			autoEditStrategy.customizeDocumentCommand(document, cmd);
 		}
+		
+		document.replace(cmd.offset, cmd.length, cmd.text);
+		caretOffset = cmd.caretOffset + (cmd.shiftsCaret ? cmd.text.length() : 0);
 	}
 	
-	private DocumentCommand createTypingCommand(String text) {
+	private DocumentCommand createInsertAtCaretCommand(String text) {
+		text = translate(text);
+		
 		if (caretOffset > document.getLength()) {
 			caretOffset = document.getLength();
 		}
@@ -95,4 +257,25 @@ public class AutoEditStrategyTest extends TestCase {
 		return cmd;
 	}
 
+	/**
+	 * Replaces characters according the mapping given in the second string. The
+	 * characters at an even index (such as index 0) will be replaced with the
+	 * character at the next index (such as index 1). Used for generating
+	 * syntactical permutations of tested FTL fragments.
+	 */
+	private String translate(String s) {
+		if (translations == null || s == null) {
+			return s;
+		}
+		for (int i = 0; i < translations.length(); i += 2) {
+			s = s.replace(translations.charAt(i), translations.charAt(i + 1));
+		}
+		return s;
+	}
+	
+	private void assertContentWithCaret(String expected) {
+		String content = translate(document.get());
+		Assert.assertEquals(translate(expected), content.substring(0, caretOffset) + "|" + content.substring(caretOffset));
+	}
+	
 }

--- a/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/ErrorMarkerTest.java
+++ b/tests/org.jboss.ide.eclipse.freemarker.test/src/org/jboss/ide/eclipse/freemarker/editor/test/ErrorMarkerTest.java
@@ -21,17 +21,11 @@
  */
 package org.jboss.ide.eclipse.freemarker.editor.test;
 
-import java.util.Map;
-
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.ide.ResourceUtil;
 import org.eclipse.ui.texteditor.MarkerUtilities;
 import org.jboss.ide.eclipse.freemarker.editor.Editor;


### PR DESCRIPTION
This fixes the way ">" is inserted after "<#" (i.e., now it happens with a single visual update, and doesn't use KeyEvent hacks anymore), and adds the missing auto-closings as described in the Jira issue. The original double-">"/"}" filtering was re-implemented without the KeyEvent-s too.